### PR TITLE
Bugfix/coveralls metadata

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
 
   hygiene-checks:
     name: Hygiene checks (audit, coverage, formatting) on ${{ matrix.os }}
-    needs: [release-tests, debug-tests, nightly-checks]
+    #needs: [release-tests, debug-tests, nightly-checks]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
 
   hygiene-checks:
     name: Hygiene checks (audit, coverage, formatting) on ${{ matrix.os }}
-    #needs: [release-tests, debug-tests, nightly-checks]
+    needs: [release-tests, debug-tests, nightly-checks]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Audit
         run: cargo audit -D warnings
       - name: Coverage
-        run: cargo tarpaulin --ignore-tests --run-types AllTargets Tests Benchmarks Bins Doctests Lib --fail-under 90 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: cargo tarpaulin --ignore-tests --run-types AllTargets Tests Benchmarks Bins Lib --fail-under 90 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
       - name: Format
         run: cargo fmt -- --check
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,10 +84,10 @@ jobs:
   hygiene-checks:
     name: Hygiene checks (audit, coverage, formatting) on ${{ matrix.os }}
     needs: [release-tests, debug-tests, nightly-checks]
-    runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:develop-nightly
-      options: --security-opt seccomp=unconfined
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
     defaults:
       run:
         working-directory: ${{ env.SRC_DIR }}
@@ -98,7 +98,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.4.0
       - name: Setup
-        run: cargo install cargo-audit # and install dependencies
+        run: cargo install cargo-audit cargo-tarpaulin # and install dependencies
       - name: Audit
         run: cargo audit -D warnings
       - name: Coverage


### PR DESCRIPTION
Fixes a bug where the branch metadata is not uploaded to Coveralls with the test report data, therefore all commits for the last month have not been tagged to a branch. This unfortunately requires going back to stable rust and means we cannot get coverage data for doctests.

Warning in github actions:
![image](https://github.com/XtensibleBinaryFormat/XBF/assets/43225907/d06c82cd-1e0a-456b-89a4-b47a4097547d)

Examples of the regression:
![image](https://github.com/XtensibleBinaryFormat/XBF/assets/43225907/4d307d09-0a61-46f1-a8f0-130e040bd8ed)

Screenshot of the regression fixed:
![image](https://github.com/XtensibleBinaryFormat/XBF/assets/43225907/dd5bd974-3537-4879-9e40-0e57c11497c2)
