### PR TITLE
fix breaking change due to upstream change in tarpaulin functionality…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Audit
         run: cargo audit -D warnings
       - name: Coverage
-        run: cargo tarpaulin --ignore-tests --run-types AllTargets Tests Benchmarks Bins Lib --fail-under 90 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: cargo tarpaulin --ignore-tests --all-targets --fail-under 90 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
       - name: Format
         run: cargo fmt -- --check
 


### PR DESCRIPTION
…. hygiene check now uses generic --all-targets