### PR TITLE
Re-enable checks monthly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,9 @@ on:
     branches: ["main"]
     paths:
       - "xbf_rs/**"
-  # schedule:
-  #   - cron: "00 18 * * *"
+  # Re-enabling, but enforcing scans monthly so as to reduce noice
+  schedule:
+     - cron: "00 18 1 * *"
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
Looks like the audit check that was failing was an openssl break that has since been fixed. I don't want to cause a ton of noise but it would be nice to know if something breaks in the future.